### PR TITLE
refactor/legacy_audio

### DIFF
--- a/ovos_plugin_vlc/__init__.py
+++ b/ovos_plugin_vlc/__init__.py
@@ -1,21 +1,12 @@
-from ovos_utils.log import LOG
-from ovos_bus_client.message import Message
-from ovos_plugin_common_play.ocp.base import OCPAudioPlayerBackend
-from ovos_plugin_common_play.ocp.status import TrackState, \
-    MediaState, PlayerState
-import vlc
 import time
+from typing import List
+
+import vlc
+from ovos_plugin_manager.templates.audio import AudioBackend
+from ovos_utils.log import LOG
 
 
-VLCAudioPluginConfig = {
-    "vlc": {
-        "type": "ovos_vlc",
-        "active": True
-    }
-}
-
-
-class OVOSVlcService(OCPAudioPlayerBackend):
+class OVOSVlcService(AudioBackend):
     def __init__(self, config, bus=None, name='ovos_vlc'):
         super(OVOSVlcService, self).__init__(config, bus)
         self.instance = vlc.Instance("--no-video")
@@ -28,7 +19,7 @@ class OVOSVlcService(OCPAudioPlayerBackend):
         self.vlc_events.event_attach(vlc.EventType.MediaPlayerTimeChanged,
                                      self.update_playback_time, None)
         self.vlc_events.event_attach(vlc.EventType.MediaPlayerEndReached,
-                                          self.queue_ended, 0)
+                                     self.queue_ended, 0)
         self.vlc_events.event_attach(vlc.EventType.MediaPlayerEncounteredError,
                                      self.handle_vlc_error, None)
 
@@ -41,12 +32,8 @@ class OVOSVlcService(OCPAudioPlayerBackend):
         self.player.audio_set_volume(100)
         self._last_sync = 0
 
+    ###################
     # vlc internals
-    @property
-    def playback_time(self):
-        """ in milliseconds """
-        return self._playback_time
-
     def handle_vlc_error(self, data, other):
         self.ocp_error()
 
@@ -59,9 +46,7 @@ class OVOSVlcService(OCPAudioPlayerBackend):
             # the gui seems to lag a lot when sending messages too often,
             # gui expected to keep an internal fake progress bar and sync periodically
             self._last_sync = time.time()
-            self.bus.emit(Message("ovos.common_play.playback_time",
-                                  {"position": self._playback_time,
-                                   "length": self.get_track_length()}))
+            self.ocp_sync_playback(self._playback_time)
 
     def track_start(self, data, other):
         LOG.debug('VLC playback start')
@@ -74,10 +59,21 @@ class OVOSVlcService(OCPAudioPlayerBackend):
         if self._track_start_callback:
             self._track_start_callback(None)
 
-    def supported_uris(self):
+    ############
+    # mandatory abstract methods
+    @property
+    def playback_time(self):
+        """ in milliseconds """
+        return self._playback_time
+
+    def supported_uris(self) -> List[str]:
+        """List of supported uri types.
+
+        Returns:
+            list: Supported uri's
+        """
         return ['file', 'http', 'https']
 
-    # audio service
     def play(self, repeat=False):
         """ Play playlist using vlc. """
         LOG.debug('VLCService Play')
@@ -104,6 +100,12 @@ class OVOSVlcService(OCPAudioPlayerBackend):
         """ Resume paused playback. """
         self.player.set_pause(0)
         self.ocp_resume()  # emit ocp state events
+
+    def lower_volume(self):
+        self.player.audio_set_volume(self.low_volume)
+
+    def restore_volume(self):
+        self.player.audio_set_volume(100)
 
     def track_info(self):
         """ Extract info of current track. """
@@ -171,3 +173,11 @@ def load_service(base_config, bus):
                 backends[b].get('active', False)]
     instances = [OVOSVlcService(s[1], bus, s[0]) for s in services]
     return instances
+
+
+VLCAudioPluginConfig = {
+    "vlc": {
+        "type": "ovos_vlc",
+        "active": True
+    }
+}

--- a/ovos_plugin_vlc/__init__.py
+++ b/ovos_plugin_vlc/__init__.py
@@ -2,6 +2,7 @@ import time
 from typing import List
 
 import vlc
+from ovos_bus_client.message import Message
 from ovos_plugin_manager.templates.audio import AudioBackend
 from ovos_utils.log import LOG
 
@@ -46,7 +47,12 @@ class OVOSVlcService(AudioBackend):
             # the gui seems to lag a lot when sending messages too often,
             # gui expected to keep an internal fake progress bar and sync periodically
             self._last_sync = time.time()
-            self.ocp_sync_playback(self._playback_time)
+            try:
+                self.ocp_sync_playback(self._playback_time)
+            except:  # too old OPM version
+                self.bus.emit(Message("ovos.common_play.playback_time",
+                                      {"position": self._playback_time,
+                                       "length": self.get_track_length()}))
 
     def track_start(self, data, other):
         LOG.debug('VLC playback start')

--- a/ovos_plugin_vlc/__init__.py
+++ b/ovos_plugin_vlc/__init__.py
@@ -77,7 +77,6 @@ class OVOSVlcService(AudioBackend):
     def play(self, repeat=False):
         """ Play playlist using vlc. """
         LOG.debug('VLCService Play')
-        self.ocp_start()  # emit ocp state events
         track = self.instance.media_new(self._now_playing)
         self.player.set_media(track)
         self.player.play()
@@ -87,19 +86,16 @@ class OVOSVlcService(AudioBackend):
         LOG.info('VLCService Stop')
         if self.player.is_playing():
             self.player.stop()
-            self.ocp_stop()  # emit ocp state events
             return True
         return False
 
     def pause(self):
         """ Pause vlc playback. """
         self.player.set_pause(1)
-        self.ocp_pause()  # emit ocp state events
 
     def resume(self):
         """ Resume paused playback. """
         self.player.set_pause(0)
-        self.ocp_resume()  # emit ocp state events
 
     def lower_volume(self):
         self.player.audio_set_volume(self.low_volume)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,2 @@
 ovos-plugin-manager
-ovos_plugin_common_play
 python-vlc>=1.1.2


### PR DESCRIPTION
add missing abstract methods

drop dependency on common_play base class

helps keeping the legacy plugins alive independently of OCP

companion PR: https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/226 https://github.com/OpenVoiceOS/ovos-audio/pull/64