### PR TITLE
fix/ducking

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,2 @@
-ovos-plugin-manager
+ovos-plugin-manager>=0.0.26a29
 python-vlc>=1.1.2


### PR DESCRIPTION
VLC wouldnt restore volume after stop had been called

first i tried to add some retries, then i tried to restore the volume when payback starts, these approaches did not work

idk what the core issue is, but remedied around it by creating a fresh VLC instance on playback start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved playback controls with enhanced play, stop, pause, and resume functionalities.
  - Added volume management options allowing users to lower and restore volume seamlessly.
  - Enhanced track information retrieval, including track length and position info.
  - Added new seeking capabilities to move forward or backward within a track.

- **Dependencies**
  - Updated `ovos-plugin-manager` to version `>=0.0.26a29`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->